### PR TITLE
Style updates

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -140,6 +140,12 @@ a {
   color: $light;
 }
 
+pre {
+  background-color: darkgrey;
+  padding: 1.5rem;
+  border-radius: 10px;
+}
+
 
 
 /* ---------- WAVES ---------- */

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -5,7 +5,6 @@
 <title>{% block title %}{% endblock %}</title>
 <link rel="stylesheet" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}">
 {% block dark-mode-vars %}
-  <link rel="stylesheet" href="{% static "admin/css/dark_mode.css" %}">
   <script src="{% static "admin/js/theme.js" %}" defer></script>
 {% endblock %}
 {% if not is_popup and is_nav_sidebar_enabled %}
@@ -100,8 +99,8 @@
         {% block nav-breadcrumbs %}
             <nav aria-label="{% translate 'Breadcrumbs' %}" class="bg-secondary text-dark">
                 {% block breadcrumbs %}
-                    <div class="breadcrumbs">
-                        <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+                    <div class="breadcrumb">
+                        <a href="{% url 'admin:index' %}" class="breadcrumb-item">{% translate 'Home' %}</a>
                         {% if title %} &rsaquo; {{ title }}{% endif %}
                     </div>
                 {% endblock %}


### PR DESCRIPTION
Updating pre blocks to differentiate code on blog posts.

Blog posts are using `<pre>` blocks surrounding `<code>` blocks to ensure spacing stays correct.

Potentially may style code in the future for the lines that are just surrounded my `<code>` blocks to differentiate them as well.

Removed dark mode from admin base for time being and styled admin breadcrumbs with bootstrap5 classes.